### PR TITLE
Remove the version stanza

### DIFF
--- a/docker-compose.solr.yaml
+++ b/docker-compose.solr.yaml
@@ -1,5 +1,4 @@
 #ddev-generated
-version: '3.6'
 services:
   solr:
     container_name: ddev-${DDEV_SITENAME}-solr


### PR DESCRIPTION
The `version` stanza is obsolete, so might as well be removed here. 